### PR TITLE
Add delivery service listener

### DIFF
--- a/delivery-service/src/main/java/org/example/listener/DeliveryEventListener.java
+++ b/delivery-service/src/main/java/org/example/listener/DeliveryEventListener.java
@@ -1,0 +1,37 @@
+package org.example.listener;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.example.events.PaymentConfirmedEvent;
+import org.example.events.PaymentFailedEvent;
+import org.example.model.DeliveryStatus;
+import org.example.service.DeliveryService;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import static org.example.kafka.constants.KafkaGroups.DELIVERY_SERVICE;
+import static org.example.kafka.constants.KafkaTopics.PAYMENT_EVENTS;
+
+@Component
+public class DeliveryEventListener {
+
+    private final DeliveryService deliveryService;
+
+    public DeliveryEventListener(DeliveryService deliveryService) {
+        this.deliveryService = deliveryService;
+    }
+
+    @KafkaListener(topics = PAYMENT_EVENTS, groupId = DELIVERY_SERVICE)
+    public void listen(ConsumerRecord<String, Object> record) {
+        Object event = record.value();
+
+        if (event instanceof PaymentConfirmedEvent confirmed) {
+            System.out.println("📥 Delivery-service отримав PaymentConfirmedEvent: " + event);
+            deliveryService.createDelivery(confirmed.getOrderId(), confirmed.getTotalAmount());
+        } else if (event instanceof PaymentFailedEvent failed) {
+            System.out.println("📥 Delivery-service отримав PaymentFailedEvent: " + event);
+            deliveryService.updateStatus(failed.getOrderId(), DeliveryStatus.CANCELLED);
+        } else {
+            System.out.println("⚠️ Невідомий тип події: " + event.getClass().getName());
+        }
+    }
+}

--- a/delivery-service/src/main/java/org/example/repository/DeliveryRepository.java
+++ b/delivery-service/src/main/java/org/example/repository/DeliveryRepository.java
@@ -4,4 +4,5 @@ import org.example.model.Delivery;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DeliveryRepository extends JpaRepository<Delivery, String> {
+    Delivery findByOrderId(String orderId);
 }

--- a/delivery-service/src/main/java/org/example/service/DeliveryService.java
+++ b/delivery-service/src/main/java/org/example/service/DeliveryService.java
@@ -1,0 +1,36 @@
+package org.example.service;
+
+import org.example.model.Delivery;
+import org.example.model.DeliveryStatus;
+import org.example.repository.DeliveryRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+public class DeliveryService {
+
+    private final DeliveryRepository repository;
+
+    public DeliveryService(DeliveryRepository repository) {
+        this.repository = repository;
+    }
+
+    public Delivery createDelivery(String orderId, double amount) {
+        Delivery delivery = new Delivery();
+        delivery.setOrderId(orderId);
+        delivery.setAmount(amount);
+        return repository.save(delivery);
+    }
+
+    @Transactional
+    public void updateStatus(String orderId, DeliveryStatus status) {
+        Delivery delivery = repository.findByOrderId(orderId);
+        if (delivery != null) {
+            delivery.setStatus(status);
+            delivery.setUpdatedAt(LocalDateTime.now());
+            repository.save(delivery);
+        }
+    }
+}

--- a/kafka-core/src/main/java/org/example/kafka/constants/KafkaGroups.java
+++ b/kafka-core/src/main/java/org/example/kafka/constants/KafkaGroups.java
@@ -8,4 +8,5 @@ public final class KafkaGroups {
     public static final String INVENTORY_SERVICE = "inventory-group";
     public static final String PAYMENT_SERVICE = "payment-group";
     public static final String PRODUCT_SERVICE = "product-group";
+    public static final String DELIVERY_SERVICE = "delivery-group";
 }


### PR DESCRIPTION
## Summary
- implement DeliveryService with CRUD helpers
- listen to payment events to create and cancel deliveries
- support DELIVERY_SERVICE Kafka group

## Testing
- `mvn -q -pl delivery-service -am test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6845a05e72a08330af95553587aa4265