### PR TITLE
Add delivery Postgres container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# E-commerce Microservices System
+
+This project contains several Spring Boot services orchestrated with Kafka for inter-service communication.
+Docker Compose provides infrastructure dependencies like Kafka, Zookeeper, and PostgreSQL databases for each service.
+
+## Running the stack
+
+Use Docker Compose to start all required services:
+
+```bash
+docker-compose up -d
+```
+
+This starts Kafka, monitoring tools (Prometheus, Grafana, Jaeger), and separate PostgreSQL containers for each microservice.
+
+A new **delivery_postgres** container was added for the delivery service and listens on port `5436`. Its data is persisted in the `delivery_data` volume.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,6 +148,18 @@ services:
     volumes:
       - payment_data:/var/lib/postgresql/data
 
+  delivery_postgres:
+    image: postgres:15
+    container_name: delivery_postgres
+    environment:
+      POSTGRES_DB: deliveries-db
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5436:5432"
+    volumes:
+      - delivery_data:/var/lib/postgresql/data
+
 volumes:
   grafana-storage:
   prometheus-data:
@@ -155,4 +167,5 @@ volumes:
   product_data:
   inventory_data:
   payment_data:
+  delivery_data:
 


### PR DESCRIPTION
## Summary
- add delivery_postgres service in docker compose
- persist delivery data in new volume
- document container startup and new database

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6845a1db576883308a0e0332c497ddfc