### PR TITLE
Add delivery status endpoint

### DIFF
--- a/delivery-service/src/main/java/org/example/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/org/example/controller/DeliveryController.java
@@ -1,0 +1,38 @@
+package org.example.controller;
+
+import org.example.dto.DeliveryStatusResponse;
+import org.example.model.Delivery;
+import org.example.service.DeliveryService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/deliveries")
+public class DeliveryController {
+
+    private final DeliveryService deliveryService;
+
+    public DeliveryController(DeliveryService deliveryService) {
+        this.deliveryService = deliveryService;
+    }
+
+    @GetMapping("/{orderId}")
+    public ResponseEntity<DeliveryStatusResponse> getDeliveryStatus(@PathVariable String orderId) {
+        Delivery delivery = deliveryService.findByOrderId(orderId);
+        if (delivery == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new DeliveryStatusResponse(orderId, null, null, "Delivery not found"));
+        }
+        DeliveryStatusResponse response = new DeliveryStatusResponse(
+                delivery.getOrderId(),
+                delivery.getStatus(),
+                delivery.getId(),
+                null
+        );
+        return ResponseEntity.ok(response);
+    }
+}

--- a/delivery-service/src/main/java/org/example/dto/DeliveryStatusResponse.java
+++ b/delivery-service/src/main/java/org/example/dto/DeliveryStatusResponse.java
@@ -1,0 +1,33 @@
+package org.example.dto;
+
+import org.example.model.DeliveryStatus;
+
+public class DeliveryStatusResponse {
+    private String orderId;
+    private DeliveryStatus status;
+    private String deliveryId;
+    private String errorMessage;
+
+    public DeliveryStatusResponse(String orderId, DeliveryStatus status, String deliveryId, String errorMessage) {
+        this.orderId = orderId;
+        this.status = status;
+        this.deliveryId = deliveryId;
+        this.errorMessage = errorMessage;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public DeliveryStatus getStatus() {
+        return status;
+    }
+
+    public String getDeliveryId() {
+        return deliveryId;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+}

--- a/delivery-service/src/main/java/org/example/service/DeliveryService.java
+++ b/delivery-service/src/main/java/org/example/service/DeliveryService.java
@@ -24,6 +24,10 @@ public class DeliveryService {
         return repository.save(delivery);
     }
 
+    public Delivery findByOrderId(String orderId) {
+        return repository.findByOrderId(orderId);
+    }
+
     @Transactional
     public void updateStatus(String orderId, DeliveryStatus status) {
         Delivery delivery = repository.findByOrderId(orderId);


### PR DESCRIPTION
## Summary
- add `DeliveryStatusResponse` DTO
- expose `/api/deliveries/{orderId}` to get delivery info
- allow querying delivery by order ID in service

## Testing
- `mvn -q -pl delivery-service test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6845a6a8d2d48330b7f3073b648b3b80