### PR TITLE
Add notification service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,6 +160,18 @@ services:
     volumes:
       - delivery_data:/var/lib/postgresql/data
 
+  notification_postgres:
+    image: postgres:15
+    container_name: notification_postgres
+    environment:
+      POSTGRES_DB: notifications-db
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5437:5432"
+    volumes:
+      - notification_data:/var/lib/postgresql/data
+
 volumes:
   grafana-storage:
   prometheus-data:
@@ -168,4 +180,5 @@ volumes:
   inventory_data:
   payment_data:
   delivery_data:
+  notification_data:
 

--- a/notification-service/pom.xml
+++ b/notification-service/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.example</groupId>
+        <artifactId>kafka-microservices</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>notification-service</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>16</source>
+                    <target>16</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/notification-service/src/main/java/org/example/NotificationServiceApplication.java
+++ b/notification-service/src/main/java/org/example/NotificationServiceApplication.java
@@ -1,0 +1,11 @@
+package org.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class NotificationServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(NotificationServiceApplication.class, args);
+    }
+}

--- a/notification-service/src/main/java/org/example/controller/NotificationController.java
+++ b/notification-service/src/main/java/org/example/controller/NotificationController.java
@@ -1,0 +1,39 @@
+package org.example.controller;
+
+import org.example.dto.NotificationResponse;
+import org.example.model.Notification;
+import org.example.service.NotificationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    public NotificationController(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    @GetMapping("/{orderId}")
+    public ResponseEntity<List<NotificationResponse>> getNotifications(@PathVariable String orderId) {
+        List<Notification> notifications = notificationService.getNotificationsForOrder(orderId);
+        List<NotificationResponse> response = notifications.stream()
+                .map(n -> new NotificationResponse(n.getId(), n.getOrderId(), n.getMessage(), n.getCreatedAt()))
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/send/test")
+    public ResponseEntity<NotificationResponse> sendTestNotification() {
+        Notification notification = notificationService.createNotification("test-order", "Test notification");
+        NotificationResponse response = new NotificationResponse(
+                notification.getId(), notification.getOrderId(), notification.getMessage(), notification.getCreatedAt()
+        );
+        return ResponseEntity.ok(response);
+    }
+}

--- a/notification-service/src/main/java/org/example/dto/NotificationResponse.java
+++ b/notification-service/src/main/java/org/example/dto/NotificationResponse.java
@@ -1,0 +1,33 @@
+package org.example.dto;
+
+import java.time.LocalDateTime;
+
+public class NotificationResponse {
+    private String id;
+    private String orderId;
+    private String message;
+    private LocalDateTime createdAt;
+
+    public NotificationResponse(String id, String orderId, String message, LocalDateTime createdAt) {
+        this.id = id;
+        this.orderId = orderId;
+        this.message = message;
+        this.createdAt = createdAt;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/notification-service/src/main/java/org/example/model/Notification.java
+++ b/notification-service/src/main/java/org/example/model/Notification.java
@@ -1,0 +1,63 @@
+package org.example.model;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "notifications")
+public class Notification {
+
+    @Id
+    private String id;
+
+    private String orderId;
+
+    private String message;
+
+    private LocalDateTime createdAt;
+
+    public Notification() {
+        this.id = UUID.randomUUID().toString();
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public Notification(String orderId, String message) {
+        this();
+        this.orderId = orderId;
+        this.message = message;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public void setOrderId(String orderId) {
+        this.orderId = orderId;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/notification-service/src/main/java/org/example/repository/NotificationRepository.java
+++ b/notification-service/src/main/java/org/example/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package org.example.repository;
+
+import org.example.model.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, String> {
+    List<Notification> findByOrderId(String orderId);
+}

--- a/notification-service/src/main/java/org/example/service/NotificationService.java
+++ b/notification-service/src/main/java/org/example/service/NotificationService.java
@@ -1,0 +1,26 @@
+package org.example.service;
+
+import org.example.model.Notification;
+import org.example.repository.NotificationRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class NotificationService {
+
+    private final NotificationRepository repository;
+
+    public NotificationService(NotificationRepository repository) {
+        this.repository = repository;
+    }
+
+    public List<Notification> getNotificationsForOrder(String orderId) {
+        return repository.findByOrderId(orderId);
+    }
+
+    public Notification createNotification(String orderId, String message) {
+        Notification notification = new Notification(orderId, message);
+        return repository.save(notification);
+    }
+}

--- a/notification-service/src/main/resources/application.yml
+++ b/notification-service/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+server:
+  port: 8086
+
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5437/notifications-db
+    username: postgres
+    password: postgres
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+    database-platform: org.hibernate.dialect.PostgreSQLDialect

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <module>kafka-core</module>
         <module>shared-events</module>
         <module>delivery-service</module>
+        <module>notification-service</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## Summary
- add notification-service module with JPA entity, repository, service, and controller
- support fetching notifications by order ID and sending a test notification
- include configuration and Postgres container in compose
- register the module in the Maven build

## Testing
- `mvn -q -pl notification-service test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a8e42df48330a76a61e1d1b08e92